### PR TITLE
'Records' element treated as list'

### DIFF
--- a/src/matcher.py
+++ b/src/matcher.py
@@ -20,7 +20,7 @@ def matcher_lambda_handler(event, lambda_context):
         sqs_client = boto3.client("sqs")
         rules = yara.load("output")
         efs_root_location = os.environ["ROOT_DIRECTORY"]
-        records = json.loads(event['Records'])
+        records = event['Records']
         for record in records:
             message_body = json.loads(record['body'])
 

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -84,7 +84,7 @@ def get_records(num=1):
             message
         )
     return {
-        "Records": json.dumps(records)
+        "Records": records
     }
 
 


### PR DESCRIPTION
SQS event has 'Records' element as a list instead of a json object