### PR TITLE
Run yum upgrade.

### DIFF
--- a/Dockerfile-dependencies
+++ b/Dockerfile-dependencies
@@ -1,4 +1,5 @@
 FROM amazonlinux
+RUN yum update -y && yum upgrade -y
 COPY build-dependencies.sh .
 ARG YARA_VERSION
 RUN ./build-dependencies.sh $YARA_VERSION


### PR DESCRIPTION
The latest amazonlinux image has vulnerabilities and there hasn't been a
new one pushed for three months. Running yum update and yum upgrade
fixes these vulnerabilities. This is bad practice usually but in this
case I think it's needed.
