### PR TITLE
Remove dummy AWS account number

### DIFF
--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -95,7 +95,7 @@ clean_s3_bucket = 'tdr-upload-files-intg'
 tdr_standard_dirty_key = "region:cognitoId/consignmentId/fileId"
 tdr_standard_copy_key = "consignmentId/fileId"
 location = {'LocationConstraint': 'eu-west-2'}
-output_queue_url = "https://queue.amazonaws.com/123456789012/tdr-api-update-intg"
+output_queue_url = "https://queue.amazonaws.com/aws_account_number/tdr-api-update-intg"
 
 
 def set_environment():


### PR DESCRIPTION
Dummy account number should be ignored by GitSecrets. This is case locally

Running GitSecrets in the Jenkins build is generating a false positive on the dummy account number

Remove to allow the build to pass until issue with running GitSecrets on Jenkins resolved