### PR TITLE
Set user to root

### DIFF
--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -1,6 +1,7 @@
 ARG ACCOUNT_NUMBER
 ARG VERSION
 FROM $ACCOUNT_NUMBER.dkr.ecr.eu-west-2.amazonaws.com/yara:$VERSION
+USER root
 RUN addgroup --system compilegroup && adduser --system compileuser -G compilegroup
 WORKDIR /rules
 COPY rule-sources /rules/rule-sources


### PR DESCRIPTION
Jenkins build failing with error message: addgroup: permission denied (are you root?)

Docker build working correctly locally