### PR TITLE
Fix parameters sent from Jenkins jobs to the "bundle" job

### DIFF
--- a/Jenkinsfile-build
+++ b/Jenkinsfile-build
@@ -33,7 +33,7 @@ pipeline {
           build(
               job: "TDR Antivirus Bundle",
               parameters: [
-                  string(name: "BUILD_IMAGE_TAG", value: params.STAGE)
+                  string(name: "STAGE", value: params.STAGE)
               ],
               wait: false)
       }
@@ -53,4 +53,3 @@ post {
   }
 }
 }
-

--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -37,7 +37,7 @@ pipeline {
         build(
             job: "TDR Antivirus Bundle",
             parameters: [
-                string(name: "BUILD_IMAGE_TAG", value: "intg")
+                string(name: "STAGE", value: "intg")
             ],
             wait: false)
       }


### PR DESCRIPTION
The parameter to the Jenkinsfile-bundle job was recently renamed from `BUILD_IMAGE_TAG` to `STAGE`. This commit fixes the name of that parameter in jobs which start the bundle job.

Integration builds were succeeding because the default value is "intg", but staging build were failing.