### PR TITLE
Pin moto version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3
 yara-python
-moto
+moto >= 1.3.16, < 2
 pytest
 pytest-mock
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3
 yara-python
-moto >= 1.3.16, < 2
+moto == 1.3.16
 pytest
 pytest-mock
 pytest-cov


### PR DESCRIPTION
Version 2 of moto was released about a week ago, and causes build errors like:

```
...
14:19:59  ../../.local/lib/python3.8/site-packages/moto/awslambda/__init__.py:2: in <module>
14:19:59      from .models import lambda_backends
14:19:59  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
14:19:59
14:19:59      from __future__ import unicode_literals
14:19:59
14:19:59      import base64
14:19:59      import time
14:19:59      from collections import defaultdict
14:19:59      import copy
14:19:59      import datetime
14:19:59      from gzip import GzipFile
14:19:59
14:19:59  >   import docker
14:19:59  E   ModuleNotFoundError: No module named 'docker'
14:19:59
14:19:59  ../../.local/lib/python3.8/site-packages/moto/awslambda/models.py:10: ModuleNotFoundError
```

We should fix these errors and upgrade, but pinning the version lets us fix the build in the meantime.