### PR TITLE
Push version tags to git repo

### DIFF
--- a/Jenkinsfile-bundle
+++ b/Jenkinsfile-bundle
@@ -43,9 +43,9 @@ pipeline {
           tdr.configureJenkinsGitUser()
 
           sh "git tag ${versionTag}"
-          sh "git checkout master"
-
-          tdr.pushGitHubBranch("master")
+          sshagent(['github-jenkins']) {
+            sh("git push origin ${versionTag}")
+          }
 
           build(
               job: "TDR Antivirus Deploy",


### PR DESCRIPTION
The version tags were used to label build artifacts pushed to S3. This change also pushes a git tag to make it clearer which version is pushed to each environment.

This also makes this repo consistent with the other Lambda deployments.

Marking this as a draft for now, because the build won't pass until #19 is merged.