### PR TITLE
Fix order of docker build and push steps in Jenkinsfile-build

### DIFF
--- a/Jenkinsfile-build
+++ b/Jenkinsfile-build
@@ -17,13 +17,17 @@ pipeline {
     stage('Build and push yara docker images') {
       steps {
         script {
-          sh "docker build -f Dockerfile-yara --pull --no-cache --build-arg YARA_VERSION=${yaraVersion} -t ${imageAccount}/yara:${versionTag} ."
-          sh "docker build -f Dockerfile-dependencies --pull --no-cache --build-arg YARA_VERSION=${yaraVersion} -t ${imageAccount}/yara-dependencies:${versionTag} ."
-          sh "docker build -f Dockerfile-compile  --pull --no-cache -t ${imageAccount}/yara-rules:${versionTag} --build-arg ACCOUNT_NUMBER=${env.MANAGEMENT_ACCOUNT} --build-arg VERSION=${versionTag} ."
           sh "aws ecr get-login --region eu-west-2 --no-include-email | bash"
+
+          sh "docker build -f Dockerfile-yara --pull --no-cache --build-arg YARA_VERSION=${yaraVersion} -t ${imageAccount}/yara:${versionTag} ."
           sh "docker push ${imageAccount}/yara:${versionTag}"
+
+          sh "docker build -f Dockerfile-dependencies --pull --no-cache --build-arg YARA_VERSION=${yaraVersion} -t ${imageAccount}/yara-dependencies:${versionTag} ."
           sh "docker push ${imageAccount}/yara-dependencies:${versionTag}"
+
+          sh "docker build -f Dockerfile-compile  --pull --no-cache -t ${imageAccount}/yara-rules:${versionTag} --build-arg ACCOUNT_NUMBER=${env.MANAGEMENT_ACCOUNT} --build-arg VERSION=${versionTag} ."
           sh "docker push ${imageAccount}/yara-rules:${versionTag}"
+
           sh "docker tag ${imageAccount}/yara:${versionTag} ${imageAccount}/yara:${params.STAGE}"
           sh "docker tag ${imageAccount}/yara-dependencies:${versionTag} ${imageAccount}/yara-dependencies:${params.STAGE}"
           sh "docker tag ${imageAccount}/yara-rules:${versionTag} ${imageAccount}/yara-rules:${params.STAGE}"


### PR DESCRIPTION
Push each image as it is built, rather than after building them all. Some of these images depend on ones that are built earlier in the script. Building them all together used to work, but it doesn't any more because we added the `--pull` flag, which means the base image has to be pushed to the repo so that we can pull it.