### PR TITLE
Pin version of cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytest-mock
 pytest-cov
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography == 3.3.1 # older version pinned because later versions require Rust to build


### PR DESCRIPTION
The Yara build job is currently emitting an error when the Python dependencies are installed in the Docker image:

```
13:46:51      Complete output from command python setup.py egg_info:
13:46:51
13:46:51              =============================DEBUG ASSISTANCE==========================
13:46:51              If you are seeing an error here please try the following to
13:46:51              successfully install cryptography:
13:46:51
13:46:51              Upgrade to the latest pip and try again. This will fix errors for most
13:46:51              users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
13:46:51              =============================DEBUG ASSISTANCE==========================
13:46:51
13:46:51      Traceback (most recent call last):
13:46:51        File "<string>", line 1, in <module>
13:46:51        File "/tmp/pip-build-kb6xn_rd/cryptography/setup.py", line 14, in <module>
13:46:51          from setuptools_rust import RustExtension
13:46:51      ModuleNotFoundError: No module named 'setuptools_rust'
```

We should upgrade pip, but this commit may help to fix the failing build.