### PR TITLE
Use requirements file to install runtime Python dependencies 

### DIFF
--- a/Dockerfile-dependencies
+++ b/Dockerfile-dependencies
@@ -3,6 +3,7 @@ RUN yum update -y && yum upgrade -y
 # amazonlinux image needs shadow utils to add users
 RUN yum -y install shadow-utils
 RUN useradd --system dependenciesuser
+COPY requirements-runtime.txt requirements.txt
 COPY build-dependencies.sh .
 ARG YARA_VERSION
 RUN ./build-dependencies.sh $YARA_VERSION

--- a/build-dependencies.sh
+++ b/build-dependencies.sh
@@ -23,7 +23,7 @@ make install
 cd /
 pip3 install --upgrade pip
 mkdir pip
-/usr/local/bin/pip3 install cryptography yara-python -t pip
+/usr/local/bin/pip3 install --requirement requirements.txt --target pip
 
 # Clean cryptography files
 cd /pip

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,2 @@
+cryptography == 3.3.2 # older version pinned because later versions require Rust to build
+yara-python

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+boto3
+moto == 1.3.16
+pytest
+pytest-mock
+pytest-cov
+rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-boto3
-yara-python
-moto == 1.3.16
-pytest
-pytest-mock
-pytest-cov
-rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography == 3.3.2 # older version pinned because later versions require Rust to build
+# Load all runtime and dev packages
+-r requirements-runtime.txt
+-r requirements-test.txt


### PR DESCRIPTION
Before, the requirements file was used to run the tests, but it wasn't used in the Docker container, so the runtime dependencies had to be specified separately in the script run by the Dockerfile.

This change commonises the two, so the runtime dependencies are only specified in one place (requirements-runtime.txt).

This makes it easier to maintain the list of dependencies, but it also has a security benefit, because Snyk notifies us if there are any vulnerabilities in the dependencies listed in the requirements files.

Marking this as as draft for now because I want to check this works with the pinned version of the cryptography package. That will be easier once we've sorted out the ECR alerts from the yara images.