### PR TITLE
Set specific version numbers for all dependencies

### DIFF
--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,2 +1,2 @@
 cryptography == 3.3.2 # older version pinned because later versions require Rust to build
-yara-python
+yara-python == 4.0.5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
-boto3
+boto3 == 1.17.20
 moto == 1.3.16
-pytest
-pytest-mock
-pytest-cov
+pytest == 6.2.2
+pytest-mock == 3.5.1
+pytest-cov == 2.11.1
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This makes the builds more consistent. It may also help Dependabot to upgrade depedencies when we add it.