### PR TITLE
Update yara to version 4.1

### DIFF
--- a/Jenkinsfile-build
+++ b/Jenkinsfile-build
@@ -3,7 +3,7 @@ library("tdr-jenkinslib")
 
 def versionTag = "v${env.BUILD_NUMBER}"
 def repo = "tdr-antivirus"
-def yaraVersion = "4.0.0"
+def yaraVersion = "4.1.0"
 def imageAccount = "${env.MANAGEMENT_ACCOUNT}.dkr.ecr.eu-west-2.amazonaws.com"
 
 pipeline {

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,2 +1,2 @@
 cryptography == 3.3.2 # older version pinned because later versions require Rust to build
-yara-python == 4.0.5
+yara-python == 4.1.0


### PR DESCRIPTION
Yara is now at version 4.1. For some reason I'm not sure of, the version of yara-python was incompatible with the installed version of yara and was causing errors in the av scans. I've upgraded both to 4.1 and the antivirus is working now.
