### PR TITLE
Update rule sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 dependencies.zip
 lambda/
 venv
-src/output
+output
 .idea
 __pycache__
 tdr-configurations

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dependencies.zip
 lambda/
 venv
-output
+src/output
 .idea
 __pycache__
+tdr-configurations

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -11,8 +11,7 @@ RUN apk update && apk add py3-pip wget gcc python3-dev musl-dev git && \
             chmod +x /usr/local/bin/jq && \
             pip3 install yara-python && \
             jq -r '.repositories[].url' /rules/rules.json | xargs -n1 git clone && \
-            jq -r '.repositories[].excludeDirs' /rules/rules.json | xargs -n1 rm -rf && \
-            wget https://raw.githubusercontent.com/Yara-Rules/rules/master/malware/MALW_Eicar.yar && \
+            jq -r '.repositories[].excludeDirs[]' /rules/rules.json | xargs -n1 rm -rf && \
             ./compile.py
 RUN chown -R compileuser /rules
 

--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -4,11 +4,14 @@ FROM $ACCOUNT_NUMBER.dkr.ecr.eu-west-2.amazonaws.com/yara:$VERSION
 USER root
 RUN addgroup --system compilegroup && adduser --system compileuser -G compilegroup
 WORKDIR /rules
-COPY rule-sources /rules/rule-sources
+COPY tdr-configurations/antivirus/rules.json /rules/rules.json
 COPY src/compile.py /rules/compile.py
 RUN apk update && apk add py3-pip wget gcc python3-dev musl-dev git && \
+            wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
+            chmod +x /usr/local/bin/jq && \
             pip3 install yara-python && \
-            cat rule-sources | xargs -n1 git clone && \
+            jq -r '.repositories[].url' /rules/rules.json | xargs -n1 git clone && \
+            jq -r '.repositories[].excludeDirs' /rules/rules.json | xargs -n1 rm -rf && \
             wget https://raw.githubusercontent.com/Yara-Rules/rules/master/malware/MALW_Eicar.yar && \
             ./compile.py
 RUN chown -R compileuser /rules

--- a/Jenkinsfile-build
+++ b/Jenkinsfile-build
@@ -17,6 +17,9 @@ pipeline {
     stage('Build and push yara docker images') {
       steps {
         script {
+          sshagent(['github-jenkins']) {
+            sh("git clone --branch master git@github.com:nationalarchives/tdr-configurations.git")
+          }
           sh "aws ecr get-login --region eu-west-2 --no-include-email | bash"
 
           sh "docker build -f Dockerfile-yara --pull --no-cache --build-arg YARA_VERSION=${yaraVersion} -t ${imageAccount}/yara:${versionTag} ."

--- a/Jenkinsfile-bundle
+++ b/Jenkinsfile-bundle
@@ -27,6 +27,11 @@ pipeline {
           }
         }
       }
+      post {
+        always {
+          sh("rm -rf tdr-configurations")
+        }
+      }
     }
     stage("Upload function") {
       agent {

--- a/rule-sources
+++ b/rule-sources
@@ -1,1 +1,0 @@
-https://github.com/Neo23x0/signature-base.git


### PR DESCRIPTION
Update rule sources
    
* Change the rule sources to include an exlude directory
* Get the rule sources from the private tdr-configurations repo
* Clone the repos as before in the Dockerfile-compile
* Delete the directories specified in the exclude directories
    
The exluded directories are the utils directory in the rules repository which causes yara to find a match on any file. There is also a deprecated directory in the same repo which don't compile as they're for an older version of yara.

