### PR TITLE
Fix the antivirus deploy builds

### DIFF
--- a/Jenkinsfile-build
+++ b/Jenkinsfile-build
@@ -45,6 +45,11 @@ pipeline {
               wait: false)
       }
     }
+    post {
+      always {
+        sh("rm -rf tdr-configurations")
+      }
+    }
   }
 }
 post {

--- a/Jenkinsfile-bundle
+++ b/Jenkinsfile-bundle
@@ -27,17 +27,12 @@ pipeline {
           }
         }
       }
-      post {
-        always {
-          sh("rm -rf tdr-configurations")
-        }
-      }
     }
     stage("Upload function") {
       agent {
         ecs {
           inheritFrom "aws"
-          taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRoleIntg"
+          taskrole "arn:aws:iam::${env.MANAGEMENT_ACCOUNT}:role/TDRJenkinsNodeLambdaRole${capitalize(params.STAGE)}"
         }
       }
       steps {


### PR DESCRIPTION
The post step to delete tdr-configurations was in the wrong file as that job didn't even clone tdr-configurations.

Also, one of the roles is hard coded which is stopping us deploying to staging and prod on the new Jenkins box.
