### PR TITLE
Add ability to exclude specific rules

### DIFF
--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -6,12 +6,14 @@ RUN addgroup --system compilegroup && adduser --system compileuser -G compilegro
 WORKDIR /rules
 COPY tdr-configurations/antivirus/rules.json /rules/rules.json
 COPY src/compile.py /rules/compile.py
+COPY src/exclude_rules.py /rules/exclude_rules.py
 RUN apk update && apk add py3-pip wget gcc python3-dev musl-dev git && \
-            wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
+            wget -q https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq && \
             chmod +x /usr/local/bin/jq && \
-            pip3 install yara-python && \
+            pip3 install yara-python plyara && \
             jq -r '.repositories[].url' /rules/rules.json | xargs -n1 git clone && \
             jq -r '.repositories[].excludeDirs[]' /rules/rules.json | xargs -n1 rm -rf && \
+            ./exclude_rules.py && \
             ./compile.py
 RUN chown -R compileuser /rules
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ pytest == 6.2.2
 pytest-mock == 3.5.1
 pytest-cov == 2.11.1
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
+plyara == 2.1.1

--- a/src/exclude_rules.py
+++ b/src/exclude_rules.py
@@ -1,0 +1,27 @@
+#! /usr/bin/python3
+import json
+import plyara
+from plyara.utils import rebuild_yara_rule
+
+parser = plyara.Plyara()
+
+
+def exclude_rules(rules_file_name):
+    with open(rules_file_name, "r") as rules_json_file:
+        rules_json = json.loads(rules_json_file.read())
+        for repository in rules_json["repositories"]:
+            excluded_rules = repository["excludeRules"]
+            for file_name in excluded_rules.keys():
+                rule_names = excluded_rules[file_name]
+                with open(file_name, 'r') as file:
+                    yara_rules = parser.parse_string(file.read())
+                    filtered_rules = [rule for rule in yara_rules if rule['rule_name'] not in rule_names]
+                parser.clear()
+
+                with open(file_name, 'w') as file:
+                    for rule in filtered_rules:
+                        file.write(rebuild_yara_rule(rule))
+
+
+if __name__ == "__main__":
+    exclude_rules("/rules/rules.json")

--- a/test/test_exclude_rules.py
+++ b/test/test_exclude_rules.py
@@ -1,0 +1,15 @@
+from src.exclude_rules import exclude_rules
+import plyara
+import shutil
+import os
+
+
+def test_exclude_rules():
+    parser = plyara.Plyara()
+    shutil.copy("test/testrules/test.yar", "test.yar")
+    exclude_rules("test/testrules.json")
+    with open("test.yar", 'r') as test_yar_file:
+        parsed = parser.parse_string(test_yar_file.read())
+    assert len(parsed) == 1
+    assert parsed[0]["rule_name"] == "IncludedRule"
+    os.remove("test.yar")

--- a/test/testrules.json
+++ b/test/testrules.json
@@ -1,0 +1,11 @@
+{
+  "repositories": [
+    {
+      "excludeRules": {
+        "test.yar": [
+          "ExcludedRule"
+        ]
+      }
+    }
+  ]
+}

--- a/test/testrules/test.yar
+++ b/test/testrules/test.yar
@@ -1,0 +1,13 @@
+rule ExcludedRule
+{
+	strings:
+		$c0 = /test/
+	condition:
+		$c0
+}
+
+rule IncludedRule
+{
+	strings:
+		$c0 = /test/
+}


### PR DESCRIPTION
This uses the plyara library to parse the rules files specified in the rules json. The parsed rules are then filtered to exclude any rule names  specified in rules.json and the filtered rules are written back to the file. This allows us to exclude a single rule if it's causing us problems so we don't have to exclude the whole file. Linked to https://github.com/nationalarchives/tdr-configurations/pull/74
