### PR TITLE
Delete individual files.

### DIFF
--- a/Dockerfile-compile
+++ b/Dockerfile-compile
@@ -13,6 +13,7 @@ RUN apk update && apk add py3-pip wget gcc python3-dev musl-dev git && \
             pip3 install yara-python plyara && \
             jq -r '.repositories[].url' /rules/rules.json | xargs -n1 git clone && \
             jq -r '.repositories[].excludeDirs[]' /rules/rules.json | xargs -n1 rm -rf && \
+            jq -r '.repositories[].excludeFiles[]' /rules/rules.json | xargs -n1 rm -f && \
             ./exclude_rules.py && \
             ./compile.py
 RUN chown -R compileuser /rules


### PR DESCRIPTION
There is an excludeDirs property in antivirus configuration json which
is meant to exclude entire directories.

Adding individual files to this list will work but it could be confusing
having a single file in the excludeDirs list so I've added in an
excludeFiles attribute.
