### PR TITLE
Delete the tdr-configurations and lambda folders after each build.

### DIFF
--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -112,6 +112,7 @@ pipeline {
       script {
         sh "docker stop dependencies | true"
         sh "docker stop rules | true"
+        sh "rm -rf tdr-configurations lambda"
       }
     }
   }


### PR DESCRIPTION
It's failing at the moment because it's trying to create them and we
should start clean every build.
