### PR TITLE
Remove cognito id and get dirty bucket name from input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,18 @@ Install dependencies
 
 `pip install -r requirements.txt`
 
-To run it, you will need to add code to the matcher.py file at the bottom.
+To run it, you will need to add code to the matcher.py file at the bottom. This will connect to the integration s3 dirty bucket so you will need to run it with integration credentials.
 
 ```python
 matcher_lambda_handler({
   "Records": [
     {
       "body": {
-        "cognitoId": "cognitoId1234",
+        "userId": "7ad28066-7a76-4e07-b540-f005b6919328",
         "consignmentId": "bf2181c7-70e4-448d-b122-be561d0e797a",
         "fileId": "df216308-e78b-4328-90ef-8e4ebfef6b9d",
-        "originalPath": "original/path"
+        "originalPath": "original/path",
+        "dirtyBucketName" : "tdr-upload-files-cloudfront-dirty-intg"
       }
     }
   ]

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -39,19 +39,20 @@ def matcher_lambda_handler(event, lambda_context):
             receipt_handle = record['receiptHandle']
             try:
                 message_body = json.loads(record['body'])
-                cognito_id = urllib.parse.unquote(message_body['cognitoId'])
+                user_id = message_body['userId']
                 consignment_id = message_body["consignmentId"]
                 original_path = message_body["originalPath"]
+                dirty_bucket_name = message_body["dirtyBucketName"]
                 root_path = f"{efs_root_location}/{consignment_id}"
                 file_id = message_body["fileId"]
                 match = rules.match(f"{root_path}/{original_path}")
                 results = [x.rule for x in match]
 
-                original_s3_key = f"{cognito_id}/{consignment_id}/{file_id}"
+                original_s3_key = f"{user_id}/{consignment_id}/{file_id}"
                 copy_s3_key = f"{consignment_id}/{file_id}"
 
                 copy_source = {
-                    "Bucket": "tdr-upload-files-dirty-" + environment,
+                    "Bucket": dirty_bucket_name,
                     "Key": original_s3_key
                 }
 

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -80,10 +80,11 @@ def get_records(num=1, receipt_handles=None):
     records = []
     for i in range(num):
         body = {
-            "cognitoId": "region%3AcognitoId",
+            "userId": "userId",
             "consignmentId": "consignmentId",
             "fileId": "fileId" + str(i),
-            "originalPath": "original/path"
+            "originalPath": "original/path",
+            "dirtyBucketName": "tdr-upload-files-dirty-intg"
         }
 
         message = {
@@ -104,7 +105,7 @@ input_sqs_queue = "tdr-antivirus-intg"
 dirty_s3_bucket = 'tdr-upload-files-dirty-intg'
 quarantine_s3_bucket = 'tdr-upload-files-quarantine-intg'
 clean_s3_bucket = 'tdr-upload-files-intg'
-tdr_standard_dirty_key = "region:cognitoId/consignmentId/fileId"
+tdr_standard_dirty_key = "userId/consignmentId/fileId"
 tdr_standard_copy_key = "consignmentId/fileId"
 location = {'LocationConstraint': 'eu-west-2'}
 output_queue_url = "https://queue.amazonaws.com/aws_account_number/tdr-api-update-intg"


### PR DESCRIPTION
We are changing the download files lambda to send userId instead of
cognitoId. The values will be the same but it's no longer a cognito ID
so the name is changing to avoid confusion.

We also need to pass in the dirty bucket name because we'll need the
antivirus check to work with both the existing dirty bucket and the new
cloudwatch bucket.

I've also updated the README instructions.

This can't be merged until https://github.com/nationalarchives/tdr-download-files/pull/19 is merged.