### PR TITLE
Url decode user id.

### DIFF
--- a/src/matcher.py
+++ b/src/matcher.py
@@ -39,7 +39,7 @@ def matcher_lambda_handler(event, lambda_context):
             receipt_handle = record['receiptHandle']
             try:
                 message_body = json.loads(record['body'])
-                user_id = message_body['userId']
+                user_id = urllib.parse.unquote(message_body['userId'])
                 consignment_id = message_body["consignmentId"]
                 original_path = message_body["originalPath"]
                 dirty_bucket_name = message_body["dirtyBucketName"]


### PR DESCRIPTION
I tried to deploy this in a way that wouldn't break the antivirus by
sending both the userId and the cognitoId from the download files lambda
and switching over to the userId in the code before removing cognitoId
from the download files lambda but what I forgot is that currently,
userId still has the value of cognitoId which is eu-west-2%3A5<uuid>
because the colon gets url encoded. So we still have to url decode the
value.
This will still work when we switch to use the userId in the path
because a url decoded uuid is still a uuid.
