### PR TITLE
Log the time taken as json.

### DIFF
--- a/src/matcher.py
+++ b/src/matcher.py
@@ -97,8 +97,10 @@ def matcher_lambda_handler(event, lambda_context):
                 logging.exception(failure)
 
             raise failures[0]  # We've logged the exceptions and now need the lambda to fail.
+
+        time_now = datetime.today().replace(tzinfo=timezone.utc).timestamp() * 1000
+
         for tracking in performance_tracking:
-            time_now = datetime.today().replace(tzinfo=timezone.utc).timestamp() * 1000
             tracking["timeTaken"] = (time_now - time) / 1000
             print(json.dumps(tracking))
         return outputs


### PR DESCRIPTION
This allows the performance checks to work out how long each lambda has
taken to run.

We may move this to the database in the future but this works for now.

This is python so instead of configuring the standard logger which I
don't think works, we're just printing the json string to stdout. This
does work.
