### PR TITLE
Check if file exists before download

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 boto3 == 1.17.20
 moto == 3.0.7
-pytest == 6.2.2
+pytest == 6.2.5
 pytest-mock == 3.5.1
 pytest-cov == 2.11.1
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -29,8 +29,10 @@ def matcher_lambda_handler(event, lambda_context):
 
     root_path = f"{efs_root_location}/{consignment_id}"
     file_path = f"{root_path}/{original_path}"
+    download_directory = "/".join(file_path.split("/")[:-1])
+    if not exists(download_directory):
+        os.makedirs(download_directory)
     if not exists(file_path):
-        os.makedirs("/".join(file_path.split("/")[:-1]))
         bucket = s3_resource.Bucket(dirty_bucket_name)
         bucket.download_file(f"{user_id}/{consignment_id}/{file_id}", file_path)
 

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -3,6 +3,7 @@ import boto3
 import logging
 from datetime import datetime, timezone
 import os
+from os.path import exists
 
 FORMAT = '%(asctime)-15s %(message)s'
 INFO = 20
@@ -28,9 +29,10 @@ def matcher_lambda_handler(event, lambda_context):
 
     root_path = f"{efs_root_location}/{consignment_id}"
     file_path = f"{root_path}/{original_path}"
-    os.makedirs("/".join(file_path.split("/")[:-1]))
-    bucket = s3_resource.Bucket(dirty_bucket_name)
-    bucket.download_file(f"{user_id}/{consignment_id}/{file_id}", file_path)
+    if not exists(file_path):
+        os.makedirs("/".join(file_path.split("/")[:-1]))
+        bucket = s3_resource.Bucket(dirty_bucket_name)
+        bucket.download_file(f"{user_id}/{consignment_id}/{file_id}", file_path)
 
     match = rules.match(f"{root_path}/{original_path}")
     results = [x.rule for x in match]


### PR DESCRIPTION
The lambda can keep a file in its /tmp directory while its still warm so
if we're retrying after an error, we need to check if the file is there
before we try to download it again.
