### PR TITLE
TDR 2923 fix deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     needs: pre-deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/check_rules.yml
+++ b/.github/workflows/check_rules.yml
@@ -30,7 +30,9 @@ jobs:
           cd ..
           aws s3 cp --recursive s3://tdr-antivirus-test-files-mgmt/ .
           docker build -f Dockerfile-check-rules --no-cache -t yara-run-tests .
-          docker run -e GITHUB_OUTPUT=$GITHUB_OUTPUT -v $GITHUB_OUTPUT:$GITHUB_OUTPUT yara-run-tests
+          touch output
+          docker run -e GITHUB_OUTPUT=$(pwd)/output -v $(pwd)/output:$(pwd)/output yara-run-tests
+          cat output >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         continue-on-error: true

--- a/.github/workflows/check_rules.yml
+++ b/.github/workflows/check_rules.yml
@@ -30,7 +30,6 @@ jobs:
           cd ..
           aws s3 cp --recursive s3://tdr-antivirus-test-files-mgmt/ .
           docker build -f Dockerfile-check-rules --no-cache -t yara-run-tests .
-          touch output
           docker run --user root -e GITHUB_OUTPUT=$GITHUB_OUTPUT -v $GITHUB_OUTPUT:$GITHUB_OUTPUT yara-run-tests
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/check_rules.yml
+++ b/.github/workflows/check_rules.yml
@@ -30,7 +30,7 @@ jobs:
           cd ..
           aws s3 cp --recursive s3://tdr-antivirus-test-files-mgmt/ .
           docker build -f Dockerfile-check-rules --no-cache -t yara-run-tests .
-          docker run -e GITHUB_OUTPUT=$GITHUB_OUTPUT yara-run-tests
+          docker run -e GITHUB_OUTPUT=$GITHUB_OUTPUT -v $GITHUB_OUTPUT:$GITHUB_OUTPUT yara-run-tests
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         continue-on-error: true

--- a/.github/workflows/check_rules.yml
+++ b/.github/workflows/check_rules.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Configure AWS credentials for Lambda
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/TDRGithubAvRuleChecksMgmt
           aws-region: eu-west-2

--- a/.github/workflows/check_rules.yml
+++ b/.github/workflows/check_rules.yml
@@ -30,7 +30,7 @@ jobs:
           cd ..
           aws s3 cp --recursive s3://tdr-antivirus-test-files-mgmt/ .
           docker build -f Dockerfile-check-rules --no-cache -t yara-run-tests .
-          docker run yara-run-tests
+          docker run -e GITHUB_OUTPUT=$GITHUB_OUTPUT yara-run-tests
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         continue-on-error: true

--- a/.github/workflows/check_rules.yml
+++ b/.github/workflows/check_rules.yml
@@ -31,8 +31,7 @@ jobs:
           aws s3 cp --recursive s3://tdr-antivirus-test-files-mgmt/ .
           docker build -f Dockerfile-check-rules --no-cache -t yara-run-tests .
           touch output
-          docker run -e GITHUB_OUTPUT=$(pwd)/output -v $(pwd)/output:$(pwd)/output yara-run-tests
-          cat output >> $GITHUB_OUTPUT
+          docker run --user root -e GITHUB_OUTPUT=$GITHUB_OUTPUT -v $GITHUB_OUTPUT:$GITHUB_OUTPUT yara-run-tests
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         continue-on-error: true

--- a/run_av_tests.py
+++ b/run_av_tests.py
@@ -6,32 +6,33 @@ import sys
 
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
-rules = yara.load("/rules/output")
-rules_old = yara.load("/rules/output-old")
+rules = yara.load("./output")
+rules_old = yara.load("./output-old")
 
 match_len = 0
 rules_old_id = sorted([ro.identifier for ro in rules_old])
 rules_id = sorted([r.identifier for r in rules])
 
-if rules_old_id != rules_id:
-    changed_rules = [item for item in rules_old_id if item not in rules_id]
-    logging.debug(f"Rules have changed. The following rules are different {changed_rules}")
-    for file in os.listdir("/testfiles"):
-        matches = rules.match(f"/testfiles/{file}")
-        av_message = "No match found" if len(matches) == 0 else " ".join([m.rule for m in matches])
-        logging.debug(f"{file} {av_message}")
-        if "eicar" in file.lower():
-            eicar_matches = sorted([m.rule for m in matches])
-            if eicar_matches != ["SUSP_Just_EICAR", "eicar"]:
-                logging.debug(f"Unexpected response from eicar file {' '.join(eicar_matches)}")
-                print(f"::set-output name=status::UnexpectedResponse")
+with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+    if rules_old_id != rules_id:
+        changed_rules = [item for item in rules_old_id if item not in rules_id]
+        logging.debug(f"Rules have changed. The following rules are different {changed_rules}")
+        for file in os.listdir("./testfiles"):
+            matches = rules.match(f"./testfiles/{file}")
+            av_message = "No match found" if len(matches) == 0 else " ".join([m.rule for m in matches])
+            logging.debug(f"{file} {av_message}")
+            if "eicar" in file.lower():
+                eicar_matches = sorted([m.rule for m in matches])
+                if eicar_matches != ["SUSP_Just_EICAR", "eicar"]:
+                    logging.debug(f"Unexpected response from eicar file {' '.join(eicar_matches)}")
+                    print(f"status=UnexpectedResponse", file=fh)
 
+            else:
+                match_len = match_len + len(matches)
+
+        if match_len > 0:
+            print(f"status=UnexpectedResponse", file=fh)
         else:
-            match_len = match_len + len(matches)
-
-    if match_len > 0:
-        print(f"::set-output name=status::UnexpectedResponse")
+            print(f"status=ExpectedResponse", file=fh)
     else:
-        print(f"::set-output name=status::ExpectedResponse")
-else:
-    print(f"::set-output name=status::RulesUnchanged")
+        print(f"status=RulesUnchanged", file=fh)


### PR DESCRIPTION
Replace set-output with writing to a file.

This was complicated slightly by the fact that you have to write to a file on the host machine from inside a docker container. I've done this by mounting the file inside the docker container but this needs root permissions so it's now running as root. This image is thrown away almost immediately so I think we can live with it.
