### PR TITLE
TDRD 8 add metadata virus check support

### DIFF
--- a/src/matcher.py
+++ b/src/matcher.py
@@ -4,6 +4,8 @@ import logging
 from datetime import datetime, timezone
 import os
 from os.path import exists
+from dataclasses import dataclass
+from typing import Optional
 
 FORMAT = '%(asctime)-15s %(message)s'
 INFO = 20
@@ -15,46 +17,59 @@ logger.setLevel(INFO)
 def matcher_lambda_handler(event, lambda_context):
     time = datetime.today().replace(tzinfo=timezone.utc).timestamp() * 1000
     print(event)
+    check_type = event["checkType"]
     file_id = event["fileId"]
     user_id = event["userId"]
     original_path = event["originalPath"]
     consignment_id = event["consignmentId"]
     environment = os.environ["ENVIRONMENT"]
-    dirty_bucket_name = f"tdr-upload-files-cloudfront-dirty-{environment}"
     s3_client = boto3.client("s3")
     s3_resource = boto3.resource("s3")
+    efs_root_location = os.environ["ROOT_DIRECTORY"]
+    root_path = f"{efs_root_location}/{consignment_id}"
+
+    settings = VirusCheckSettings(
+        s3_source_location=S3Location(
+            bucket="tdr-upload-files-cloudfront-dirty-" + environment,
+            key=f"{user_id}/{consignment_id}/{file_id}"
+        ),
+        s3_quarantine_location=S3Location(
+            bucket="tdr-upload-files-quarantine-" + environment,
+            key=f"{consignment_id}/{file_id}"
+        ),
+        local_download_location=f"{root_path}/{original_path}"
+    ) if check_type == "consignment" else VirusCheckSettings(
+        s3_source_location=S3Location(
+            bucket="",
+            key=""
+        ),
+        s3_quarantine_location=None,
+        local_download_location=""
+    )
 
     rules = yara.load("output")
-    efs_root_location = os.environ["ROOT_DIRECTORY"]
-
-    root_path = f"{efs_root_location}/{consignment_id}"
-    file_path = f"{root_path}/{original_path}"
-    download_directory = "/".join(file_path.split("/")[:-1])
+    download_directory = "/".join(settings.local_download_location.split("/")[:-1])
     if not exists(download_directory):
         os.makedirs(download_directory)
-    if not exists(file_path):
-        bucket = s3_resource.Bucket(dirty_bucket_name)
-        bucket.download_file(f"{user_id}/{consignment_id}/{file_id}", file_path)
+    if not exists(settings.local_download_location):
+        bucket = s3_resource.Bucket(settings.s3_source_location.bucket)
+        bucket.download_file(settings.s3_source_location.key, settings.local_download_location)
 
-    match = rules.match(f"{root_path}/{original_path}")
+    match = rules.match(settings.local_download_location)
     results = [x.rule for x in match]
 
-    original_s3_key = f"{user_id}/{consignment_id}/{file_id}"
     copy_s3_key = f"{consignment_id}/{file_id}"
 
-    copy_source = {
-        "Bucket": dirty_bucket_name,
-        "Key": original_s3_key
-    }
-
-    if len(results) > 0:
-        s3_client.copy(
-            copy_source,
-            "tdr-upload-files-quarantine-" + environment,
-            copy_s3_key
-        )
-    else:
-        s3_client.copy(copy_source, "tdr-upload-files-" + environment, copy_s3_key)
+    if settings.s3_quarantine_location is not None:
+        if len(results) > 0:
+            s3_client.copy(
+                settings.s3_source_location.as_dict(),
+                settings.s3_quarantine_location.bucket,
+                settings.s3_quarantine_location.key
+            )
+        else:
+            # TODO: Add s3_upload_location
+            s3_client.copy(settings.s3_source_location.as_dict(), "tdr-upload-files-" + environment, copy_s3_key)
 
     result = "\n".join(results)
 
@@ -68,3 +83,21 @@ def matcher_lambda_handler(event, lambda_context):
              "datetime": int(time),
              "fileId": file_id}
     }
+
+
+@dataclass(frozen=True)
+class S3Location:
+    bucket: str
+    key: str
+
+    def as_dict(self) -> object: return {
+        "Bucket": self.bucket,
+        "Key": self.key
+    }
+
+
+@dataclass(frozen=True)
+class VirusCheckSettings:
+    s3_source_location: S3Location
+    s3_quarantine_location: Optional[S3Location]
+    local_download_location: str

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -23,9 +23,9 @@ def matcher_lambda_handler(event, lambda_context):
     settings = build_settings(event)
     download_file_if_not_already_present(settings)
     rules = yara.load("output")
-    violated_rules = [x.rule for x in rules.match(settings.local_download_location)]
+    matched_antivirus_rules = [x.rule for x in rules.match(settings.local_download_location)]
 
-    if len(violated_rules) > 0:
+    if len(matched_antivirus_rules) > 0:
         if settings.s3_quarantine_location is not None:
             s3_client.copy(
                 settings.s3_source_location.as_dict(),
@@ -42,7 +42,7 @@ def matcher_lambda_handler(event, lambda_context):
 
     logger.info("Key %s processed", settings.s3_source_location.key)
 
-    return antivirus_results_dict(settings.file_id, violated_rules, handler_trigger_time)
+    return antivirus_results_dict(settings.file_id, matched_antivirus_rules, handler_trigger_time)
 
 
 @dataclass(frozen=True)

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -78,7 +78,21 @@ def build_settings(event: dict) -> VirusCheckSettings:
     environment = os.environ["ENVIRONMENT"]
     efs_root_location = os.environ["ROOT_DIRECTORY"]
     root_path = f"{efs_root_location}/{consignment_id}"
-    if scan_type == ScanType.consignment:
+    if scan_type == ScanType.metadata:
+        return VirusCheckSettings(
+            file_id=file_id,
+            s3_source_location=S3Location(
+                bucket="tdr-draft-metadata-" + environment,
+                key=f"{consignment_id}/{file_id}"
+            ),
+            s3_quarantine_location=S3Location(
+                bucket="tdr-upload-files-quarantine-" + environment,
+                key=f"{consignment_id}/metadata/{file_id}"
+            ),
+            s3_upload_location=None,
+            local_download_location=f"{root_path}/metadata/{file_id}"
+        )
+    else:
         user_id = event["userId"]
         original_path = event["originalPath"]
         return VirusCheckSettings(
@@ -96,17 +110,6 @@ def build_settings(event: dict) -> VirusCheckSettings:
                 key=f"{consignment_id}/{file_id}"
             ),
             local_download_location=f"{root_path}/{original_path}"
-        )
-    elif scan_type == ScanType.metadata:
-        return VirusCheckSettings(
-            file_id=file_id,
-            s3_source_location=S3Location(
-                bucket="tdr-draft-metadata-" + environment,
-                key=f"{consignment_id}/{file_id}"
-            ),
-            s3_quarantine_location=None,
-            s3_upload_location=None,
-            local_download_location=f"{root_path}/metadata/{file_id}"
         )
 
 

--- a/test/test_matcher.py
+++ b/test/test_matcher.py
@@ -6,6 +6,8 @@ from src import matcher
 import yara
 from botocore.errorfactory import ClientError
 
+from src.matcher import S3Location
+
 
 @pytest.fixture(scope='function')
 def aws_credentials():
@@ -61,7 +63,7 @@ class MockRulesMatchError:
         raise yara.Error()
 
 
-def get_records():
+def get_consignment_event():
     return {
         "userId": "userId",
         "consignmentId": "consignmentId",
@@ -70,8 +72,20 @@ def get_records():
     }
 
 
+def get_metadata_event():
+    return {
+        "scanType": "metadata",
+        "consignmentId": "consignmentId",
+        "fileId": "draft-metadata.csv",
+    }
+
+
 dirty_s3_bucket = 'tdr-upload-files-cloudfront-dirty-intg'
 quarantine_s3_bucket = 'tdr-upload-files-quarantine-intg'
+metadata_source_location = S3Location(
+    bucket='tdr-draft-metadata-intg',
+    key='consignmentId/draft-metadata.csv'
+)
 clean_s3_bucket = 'tdr-upload-files-intg'
 tdr_standard_dirty_key = "userId/consignmentId/fileId"
 tdr_standard_copy_key = "consignmentId/fileId"
@@ -91,7 +105,7 @@ def test_load_is_called(s3, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesMatchFound()
-    matcher.matcher_lambda_handler(get_records(), None)
+    matcher.matcher_lambda_handler(get_consignment_event(), None)
     yara.load.assert_called_once_with("output")
 
 
@@ -102,7 +116,7 @@ def test_correct_output(s3, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesMatchFound()
-    res = matcher.matcher_lambda_handler(get_records(), None)["antivirus"]
+    res = matcher.matcher_lambda_handler(get_consignment_event(), None)["antivirus"]
     assert res["software"] == "yara"
     assert res["softwareVersion"] == yara.__version__
     assert res["databaseVersion"] == "1"
@@ -115,7 +129,7 @@ def test_correct_file_id_provided(s3, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesMatchFound()
-    res = matcher.matcher_lambda_handler(get_records(), None)["antivirus"]
+    res = matcher.matcher_lambda_handler(get_consignment_event(), None)["antivirus"]
     assert res["fileId"] == "fileId"
 
 
@@ -127,7 +141,7 @@ def test_match_found(s3, mocker, tmpdir):
     mocker.patch('yara.load')
 
     yara.load.return_value = MockRulesMatchFound()
-    res = matcher.matcher_lambda_handler(get_records(), None)["antivirus"]
+    res = matcher.matcher_lambda_handler(get_consignment_event(), None)["antivirus"]
     assert res["result"] == "testmatch"
 
 
@@ -138,7 +152,7 @@ def test_no_match_found(s3, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesNoMatch()
-    res = matcher.matcher_lambda_handler(get_records(), None)["antivirus"]
+    res = matcher.matcher_lambda_handler(get_consignment_event(), None)["antivirus"]
     assert res["result"] == ""
 
 
@@ -149,7 +163,37 @@ def test_multiple_match_found(s3, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesMultipleMatchFound()
-    res = matcher.matcher_lambda_handler(get_records(), None)["antivirus"]
+    res = matcher.matcher_lambda_handler(get_consignment_event(), None)["antivirus"]
+    assert res["result"] == "testmatch\ntestmatch"
+
+
+def test_match_found_metadata(s3, mocker, tmpdir):
+    set_environment(tmpdir)
+    s3.create_bucket(Bucket=metadata_source_location.bucket, CreateBucketConfiguration=location)
+    s3.Object(metadata_source_location.bucket, metadata_source_location.key).put(Body="test")
+    mocker.patch('yara.load')
+    yara.load.return_value = MockRulesMatchFound()
+    res = matcher.matcher_lambda_handler(get_metadata_event(), None)["antivirus"]
+    assert res["result"] == "testmatch"
+
+
+def test_no_match_found_metadata(s3, mocker, tmpdir):
+    set_environment(tmpdir)
+    s3.create_bucket(Bucket=metadata_source_location.bucket, CreateBucketConfiguration=location)
+    s3.Object(metadata_source_location.bucket, metadata_source_location.key).put(Body="test")
+    mocker.patch('yara.load')
+    yara.load.return_value = MockRulesNoMatch()
+    res = matcher.matcher_lambda_handler(get_metadata_event(), None)["antivirus"]
+    assert res["result"] == ""
+
+
+def test_multiple_match_found_metadata(s3, mocker, tmpdir):
+    set_environment(tmpdir)
+    s3.create_bucket(Bucket=metadata_source_location.bucket, CreateBucketConfiguration=location)
+    s3.Object(metadata_source_location.bucket, metadata_source_location.key).put(Body="test")
+    mocker.patch('yara.load')
+    yara.load.return_value = MockRulesMultipleMatchFound()
+    res = matcher.matcher_lambda_handler(get_metadata_event(), None)["antivirus"]
     assert res["result"] == "testmatch\ntestmatch"
 
 
@@ -161,7 +205,7 @@ def test_bucket_not_found(s3, mocker, tmpdir):
         s3.Object("anotherbucket", tdr_standard_dirty_key).put(Body="test")
         mocker.patch('yara.load')
         yara.load.return_value = MockRulesNoMatch()
-        matcher.matcher_lambda_handler(get_records(), None)
+        matcher.matcher_lambda_handler(get_consignment_event(), None)
     assert err.typename == 'NoSuchBucket'
 
 
@@ -173,7 +217,7 @@ def test_key_not_found(s3, mocker, tmpdir):
         s3.Object(dirty_s3_bucket, "test0").put(Body="test")
         mocker.patch('yara.load')
         yara.load.return_value = MockRulesNoMatch()
-        matcher.matcher_lambda_handler(get_records(), None)
+        matcher.matcher_lambda_handler(get_consignment_event(), None)
     assert err.typename == 'ClientError'
 
 
@@ -184,7 +228,7 @@ def test_match_fails(s3, mocker, tmpdir):
         s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
         mocker.patch('yara.load')
         yara.load.return_value = MockRulesMatchError()
-        matcher.matcher_lambda_handler(get_records(), None)
+        matcher.matcher_lambda_handler(get_consignment_event(), None)
 
 
 def test_copy_to_quarantine(s3, s3_client, mocker, tmpdir):
@@ -194,9 +238,22 @@ def test_copy_to_quarantine(s3, s3_client, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesMatchFound()
-    matcher.matcher_lambda_handler(get_records(), None)
+    matcher.matcher_lambda_handler(get_consignment_event(), None)
     res = s3_client.get_object(Bucket=quarantine_s3_bucket, Key=tdr_standard_copy_key)
     assert res["Body"].read() == b"test"
+
+
+def test_no_copy_to_quarantine_with_match_metadata(s3, s3_client, mocker, tmpdir):
+    with pytest.raises(ClientError) as err:
+        set_environment(tmpdir)
+        s3.create_bucket(Bucket=metadata_source_location.bucket, CreateBucketConfiguration=location)
+        s3.create_bucket(Bucket=quarantine_s3_bucket, CreateBucketConfiguration=location)
+        s3.Object(metadata_source_location.bucket, metadata_source_location.key).put(Body="test")
+        mocker.patch('yara.load')
+        yara.load.return_value = MockRulesMatchFound()
+        matcher.matcher_lambda_handler(get_metadata_event(), None)
+        s3_client.get_object(Bucket=quarantine_s3_bucket, Key="consignmentId")
+    assert err.typename == 'NoSuchKey'
 
 
 def test_no_copy_to_quarantine_clean(s3, s3_client, mocker, tmpdir):
@@ -208,7 +265,7 @@ def test_no_copy_to_quarantine_clean(s3, s3_client, mocker, tmpdir):
         s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
         mocker.patch('yara.load')
         yara.load.return_value = MockRulesNoMatch()
-        matcher.matcher_lambda_handler(get_records(), None)
+        matcher.matcher_lambda_handler(get_consignment_event(), None)
         s3_client.get_object(Bucket=quarantine_s3_bucket, Key="consignmentId")
     assert err.typename == 'NoSuchKey'
 
@@ -220,9 +277,22 @@ def test_copy_to_clean_bucket(s3, s3_client, mocker, tmpdir):
     s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
     mocker.patch('yara.load')
     yara.load.return_value = MockRulesNoMatch()
-    matcher.matcher_lambda_handler(get_records(), None)
+    matcher.matcher_lambda_handler(get_consignment_event(), None)
     res = s3_client.get_object(Bucket=clean_s3_bucket, Key=tdr_standard_copy_key)
     assert res["Body"].read() == b"test"
+
+
+def test_no_copy_to_clean_without_match_metadata(s3, s3_client, mocker, tmpdir):
+    with pytest.raises(ClientError) as err:
+        set_environment(tmpdir)
+        s3.create_bucket(Bucket=metadata_source_location.bucket, CreateBucketConfiguration=location)
+        s3.create_bucket(Bucket=clean_s3_bucket, CreateBucketConfiguration=location)
+        s3.Object(metadata_source_location.bucket, metadata_source_location.key).put(Body="test")
+        mocker.patch('yara.load')
+        yara.load.return_value = MockRulesNoMatch()
+        matcher.matcher_lambda_handler(get_metadata_event(), None)
+        s3_client.get_object(Bucket=clean_s3_bucket, Key="consignmentId")
+    assert err.typename == 'NoSuchKey'
 
 
 def test_no_copy_to_clean_with_match(s3, s3_client, mocker, tmpdir):
@@ -234,6 +304,6 @@ def test_no_copy_to_clean_with_match(s3, s3_client, mocker, tmpdir):
         s3.Object(dirty_s3_bucket, tdr_standard_dirty_key).put(Body="test")
         mocker.patch('yara.load')
         yara.load.return_value = MockRulesMatchFound()
-        matcher.matcher_lambda_handler(get_records(), None)
+        matcher.matcher_lambda_handler(get_consignment_event(), None)
         s3_client.get_object(Bucket=clean_s3_bucket, Key=tdr_standard_copy_key)
     assert err.typename == 'NoSuchKey'


### PR DESCRIPTION
This refactors our antivirus lambda to support two different `scanType`s: `metadata` (for draft metadata csvs) and `consignment` (the existing functionality). We default to `consignment`, which executes the existing functionality unchanged.

For `metadata`, we look for the file to scan in a different location (namely our draft metadata bucket, under a directory named for the consignment id). The file name is taken as an argument from the caller (in practice this will probably always be `draft-metadata.csv`, but thought best to allow flexibility for the client rather than hard coding it in here).

We have a new class allowing the specification of settings including optional locations for quarantine of the file (if virus check fails) or upload (if it passes). For now these are set to none for the metadata path (the step function api will simply update the status in the db on failure, or trigger the metadata validator on success, with no additional s3 copying), but if we choose to add this in future, it should be as simple as adding values for `s3_quarantine_location` and `s3_upload_location` respectively.