### PR TITLE
Make Lambda configurable using 'event' parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,54 @@
 This is the code and configuration to carry out the antivirus checks on a single file from S3
 
+## Configuration Parameters
+
+Lambda takes parameters to configure the scanning options.
+
+| Parameter Name           | Optional | Default Value                                         | Description                                                                                      | Example                     | 
+|--------------------------|----------|-------------------------------------------------------|--------------------------------------------------------------------------------------------------|-----------------------------|
+| consignment_id           | false    | N/A                                                   | TDR UUID for the consignment the object to scan belongs to                                       |                             |
+| file_id                  | false    | N/A                                                   | Name of the object to scan                                                                       |                             |
+| user_id                  | true     | `None`                                                | TDR UUID of the user who uploaded the object to scan                                             |                             |
+| original_path            | true     | `None`                                                | Original path to the object to scan. Used to create local version of object for scanning         |                             |
+| scan_type                | true     | N/A                                                   | **Deprecated**. Use combination of optional parameters to set configuration. Type of scan to run | `metadata` / `consignment`  |
+| s3_source_bucket         | true     | `tdr-upload-files-cloudfront-dirty-{tdr environment}` | S3 bucket containing the object to scan                                                          | `{some AWS S3 bucket name}` |
+| s3_source_bucket_key     | true     | `{user_id}/{consignment_id}/{file_id}`                | S3 bucket key of the object to scan                                                              |                             |
+| s3_source_bucket_key     | true     | `{user_id}/{consignment_id}/{file_id}`                | S3 bucket key of the object to scan                                                              |                             |
+| s3_upload_bucket         | true     | `tdr-upload-files-{tdr environment}`                  | S3 bucket to copy clean objects to                                                               |                             |
+| s3_upload_bucket_key     | true     | `{consignment_id}/{file_id}`                          | S3 bucket key of clean object                                                                    |                             |
+| s3_quarantine_bucket     | true     | `tdr-upload-files-quarantine-{tdr environment}`       | S3 bucket to copy infected objects to                                                            |                             |
+| s3_quarantine_bucket_key | true     | `{consignment_id}/{file_id}`                          | S3 bucket key of infected object                                                                 |                             |
+
+
+### Example Configuration
+
+Object to scan details:
+* **Consignment Id**: `bf2181c7-70e4-448d-b122-be561d0e797a`
+* **File Id**: `myFileToScan.txt`
+* **Original Path**: `identifier1/identifer2/myFileToScan.txt`
+* **s3 Source bucket name**: `some-source-bucket`
+* **s3 source object key**: same as original path
+* **s3 clean bucket name**: `some-clean-bucket`
+* **s3 clean object key**: same as s3 source object key
+* **s3 quarantine bucket name**: `tdr-upload-files-quarantine-{tdr environment}`
+* **s3 quarantine object key**: same as s3 source object key
+
+Event configuration to support the above would be as follows:
+
+```json
+    {
+        "consignment_id": "bf2181c7-70e4-448d-b122-be561d0e797a",
+        "file_id": "myFileToScan.txt",
+        "original_path": "identifier1/identifer2/myFileToScan.txt",
+        "s3_source_bucket": "some-source-bucket",
+        "s3_source_bucket_key": "identifier1/identifer2/myFileToScan.txt",
+        "s3_upload_bucket": "some-clean-bucket",
+        "s3_upload_bucket_key": "identifier1/identifer2/myFileToScan.txt",        
+        "s3_quarantine_bucket_key": "identifier1/identifer2/myFileToScan.txt"
+   }
+```
+
+
 ## Building the lambda function
 
 The lambda function is built by GitHub actions. There are three actions in three yml files.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,9 @@ Lambda takes parameters to configure the scanning options.
 | scan_type                | true     | N/A                                                   | **Deprecated**. Use combination of optional parameters to set configuration. Type of scan to run | `metadata` / `consignment`  |
 | s3_source_bucket         | true     | `tdr-upload-files-cloudfront-dirty-{tdr environment}` | S3 bucket containing the object to scan                                                          | `{some AWS S3 bucket name}` |
 | s3_source_bucket_key     | true     | `{user_id}/{consignment_id}/{file_id}`                | S3 bucket key of the object to scan                                                              |                             |
-| s3_source_bucket_key     | true     | `{user_id}/{consignment_id}/{file_id}`                | S3 bucket key of the object to scan                                                              |                             |
 | s3_upload_bucket         | true     | `tdr-upload-files-{tdr environment}`                  | S3 bucket to copy clean objects to                                                               |                             |
 | s3_upload_bucket_key     | true     | `{consignment_id}/{file_id}`                          | S3 bucket key of clean object                                                                    |                             |
 | s3_quarantine_bucket     | true     | `tdr-upload-files-quarantine-{tdr environment}`       | S3 bucket to copy infected objects to                                                            |                             |
-| s3_quarantine_bucket_key | true     | `{consignment_id}/{file_id}`                          | S3 bucket key of infected object                                                                 |                             |
-
 
 ### Example Configuration
 
@@ -31,20 +28,18 @@ Object to scan details:
 * **s3 clean bucket name**: `some-clean-bucket`
 * **s3 clean object key**: same as s3 source object key
 * **s3 quarantine bucket name**: `tdr-upload-files-quarantine-{tdr environment}`
-* **s3 quarantine object key**: same as s3 source object key
 
 Event configuration to support the above would be as follows:
 
 ```json
     {
-        "consignment_id": "bf2181c7-70e4-448d-b122-be561d0e797a",
-        "file_id": "myFileToScan.txt",
-        "original_path": "identifier1/identifer2/myFileToScan.txt",
-        "s3_source_bucket": "some-source-bucket",
-        "s3_source_bucket_key": "identifier1/identifer2/myFileToScan.txt",
-        "s3_upload_bucket": "some-clean-bucket",
-        "s3_upload_bucket_key": "identifier1/identifer2/myFileToScan.txt",        
-        "s3_quarantine_bucket_key": "identifier1/identifer2/myFileToScan.txt"
+        "consignmentId": "bf2181c7-70e4-448d-b122-be561d0e797a",
+        "fileId": "myFileToScan.txt",
+        "originalPath": "identifier1/identifer2/myFileToScan.txt",
+        "s3SourceBucket": "some-source-bucket",
+        "s3SourceBucketKey": "identifier1/identifer2/myFileToScan.txt",
+        "s3UploadBucket": "some-clean-bucket",
+        "s3UploadBucketKey": "identifier1/identifer2/myFileToScan.txt"        
    }
 ```
 

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -71,13 +71,37 @@ class ScanType(Enum):
 
 
 def build_settings(event: dict) -> VirusCheckSettings:
-    scan_type = ScanType[event.get("scanType", "consignment")]
-    consignment_id = event["consignmentId"]
-    file_id = event["fileId"]
-
+    # TDR environment
     environment = os.environ["ENVIRONMENT"]
+    # AWS EFS root directory where object to scan is copied to for scanning
     efs_root_location = os.environ["ROOT_DIRECTORY"]
+    # TDR UUID for the consignment the object to scan belongs to
+    consignment_id = event["consignmentId"]
+    # TDR UUID of the object to scan
+    file_id = event["fileId"]
+    # Local path for copying object to scan
     root_path = f"{efs_root_location}/{consignment_id}"
+
+    # Original path to the object
+    original_path = event.get("originalPath", None)
+    # UUID of the user who uploaded the object to scan
+    user_id = event.get("userId", None)
+    # Type of scan: deprecated should use optional parameters
+    scan_type = ScanType[event.get("scanType", "consignment")]
+    # S3 bucket containing the object to scan
+    s3_source_bucket = event.get("s3SourceBucket", "tdr-upload-files-cloudfront-dirty-" + environment)
+    # S3 bucket key of the object to scan
+    s3_source_bucket_key = event.get("s3SourceBucketKey", f"{user_id}/{consignment_id}/{file_id}")
+    # S3 bucket to copy clean objects to
+    s3_upload_bucket = event.get("s3UploadBucket", "tdr-upload-files-" + environment)
+    # S3 bucket key of clean object
+    s3_upload_bucket_key = event.get("s3UploadBucketKey", f"{consignment_id}/{file_id}")
+    # S3 bucket to copy infected objects to
+    s3_quarantine_bucket = event.get("s3QuarantineBucket", "tdr-upload-files-quarantine-" + environment)
+    # S3 bucket key of infected object
+    s3_quarantine_bucket_key = event.get("s3QuarantineBucketKey", f"{consignment_id}/{file_id}")
+
+
     if scan_type == ScanType.metadata:
         return VirusCheckSettings(
             file_id=file_id,
@@ -93,24 +117,26 @@ def build_settings(event: dict) -> VirusCheckSettings:
             local_download_location=f"{root_path}/metadata/{file_id}"
         )
     else:
-        user_id = event["userId"]
-        original_path = event["originalPath"]
         return VirusCheckSettings(
             file_id=file_id,
             s3_source_location=S3Location(
-                bucket="tdr-upload-files-cloudfront-dirty-" + environment,
-                key=f"{user_id}/{consignment_id}/{file_id}"
+                bucket=s3_source_bucket,
+                key=s3_source_bucket_key
             ),
-            s3_quarantine_location=S3Location(
-                bucket="tdr-upload-files-quarantine-" + environment,
-                key=f"{consignment_id}/{file_id}"
-            ),
-            s3_upload_location=S3Location(
-                bucket="tdr-upload-files-" + environment,
-                key=f"{consignment_id}/{file_id}"
-            ),
+            s3_quarantine_location=s3_location(s3_quarantine_bucket, s3_quarantine_bucket_key),
+            s3_upload_location=s3_location(s3_upload_bucket, s3_upload_bucket_key),
             local_download_location=f"{root_path}/{original_path}"
         )
+
+
+def s3_location(s3_bucket, s3_bucket_key):
+    if s3_bucket != None and s3_bucket_key != None:
+        return S3Location(
+            bucket=s3_bucket,
+            key=s3_bucket_key
+        )
+    else:
+        None
 
 
 def download_file_if_not_already_present(settings):

--- a/src/matcher.py
+++ b/src/matcher.py
@@ -101,7 +101,6 @@ def build_settings(event: dict) -> VirusCheckSettings:
     # S3 bucket key of infected object
     s3_quarantine_bucket_key = event.get("s3QuarantineBucketKey", f"{consignment_id}/{file_id}")
 
-
     if scan_type == ScanType.metadata:
         return VirusCheckSettings(
             file_id=file_id,
@@ -123,7 +122,10 @@ def build_settings(event: dict) -> VirusCheckSettings:
                 bucket=s3_source_bucket,
                 key=s3_source_bucket_key
             ),
-            s3_quarantine_location=s3_location(s3_quarantine_bucket, s3_quarantine_bucket_key),
+            s3_quarantine_location=S3Location(
+                bucket=s3_quarantine_bucket,
+                key=s3_quarantine_bucket_key
+            ),
             s3_upload_location=s3_location(s3_upload_bucket, s3_upload_bucket_key),
             local_download_location=f"{root_path}/{original_path}"
         )


### PR DESCRIPTION
Current method for configuration using the 'scanType' parameter is rigid and brittle. If any changes occur in the calling client, eg S3 bucket changes it necessitates changes to the Lambda as well

To make configuration more flexible extend the number of event parameters that can be passed in

Set default values to ensure existing calling clients still work as expected

The 'scanType' parameter to be deprecated once all calling clients migrate over to using the event parameters